### PR TITLE
Add validation to prevent errors for products without variations

### DIFF
--- a/commerce_injected_fields_display.module
+++ b/commerce_injected_fields_display.module
@@ -5,6 +5,7 @@
  * Contains commerce_injected_fields_display.module.
  */
 
+use Drupal\commerce_product\Entity\ProductVariationInterface;
 use \Drupal\Core\Routing\RouteMatchInterface;
 use \Drupal\Core\Entity\EntityInterface;
 use \Drupal\Core\Entity\Display\EntityViewDisplayInterface;
@@ -48,7 +49,7 @@ function commerce_injected_fields_display_module_implements_alter(&$implementati
       unset($implementations['commerce_injected_fields_display']);
       $implementations['commerce_injected_fields_display'] = $group;
       break;
-      
+
   }
 }
 
@@ -58,27 +59,27 @@ function commerce_injected_fields_display_module_implements_alter(&$implementati
 function commerce_injected_fields_display_entity_extra_field_info() {
 
 	$productTypes = array_keys(\Drupal::service('entity_type.bundle.info')->getBundleInfo('commerce_product'));
-    
+
   $extra_field = [];
-    
+
   foreach($productTypes as $type) {
-    
+
     // check if product type has injected fields, add the pseduo field
-    
+
     $extra_field['commerce_product'][$type]['display']['injected_variation_fields'] = [
       'label' => t('Injected Variation Fields'),
       'description' => t('Fields injected into display from product variation'),
       'weight' => 100,
       'visible' => TRUE,
    ];
-   
+
   }
 
   return $extra_field;
 }
 
 function commerce_injected_fields_display_commerce_product_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-        
+
 	if ($display->getComponent('injected_variation_fields')) {
 		$build['injected_variation_fields'] = [];
 	}
@@ -88,7 +89,7 @@ function commerce_injected_fields_display_commerce_product_view(array &$build, E
  * Implements hook_ENTITY_TYPE_view_alter().
  */
 function commerce_injected_fields_display_commerce_product_view_alter(array &$build, Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Entity\Display\EntityViewDisplayInterface $display) {
-    
+
 	// Skip if it is not a product view.
 	if ($build['#theme'] != 'commerce_product') {
 		return;
@@ -97,35 +98,37 @@ function commerce_injected_fields_display_commerce_product_view_alter(array &$bu
 	/** @var \Drupal\Core\Entity\EntityTypeManager $entityTypeManager */
 	$entityTypeManager = Drupal::service('entity_type.manager');
 
-	/** @var \Drupal\commerce_product\ProductVariationStorageInterface $variation_storage */
+	/** @var \Drupal\commerce_product\ProductVariationStorageInterface $variationStorage */
 	$variationStorage = $entityTypeManager->getStorage('commerce_product_variation');
-
-	/** @var \Drupal\commerce_product\ProductVariationFieldRenderer $variationPrerender */
-	$variationPrerender = \Drupal::service('commerce_product.variation_field_renderer');
 
 	/** @var \Drupal\commerce_product\Entity\ProductVariation $variation */
 	$variation = $variationStorage->loadFromContext($entity);
 
-	// Use the found view mode in $build
-	$renderedFields = $variationPrerender->renderFields($variation, $build['#view_mode']);
+	if ($variation instanceof ProductVariationInterface) {
+		/** @var \Drupal\commerce_product\ProductVariationFieldRenderer $variationPrerender */
+		$variationPrerender = \Drupal::service('commerce_product.variation_field_renderer');
 
-	// Copy injected fields into the psuedo field, then remove them.
-	foreach ($renderedFields as $fieldName => $renderedField) {
-		$variationFieldName = 'variation_' . $fieldName;
-		if (isset($build[$variationFieldName])) {
-			if (isset($build['injected_variation_fields'])) {
-				$build['injected_variation_fields'][$variationFieldName] = $build[$variationFieldName];
+		// Use the found view mode in $build
+		$renderedFields = $variationPrerender->renderFields($variation, $build['#view_mode']);
+
+		// Copy injected fields into the psuedo field, then remove them.
+		foreach ($renderedFields as $fieldName => $renderedField) {
+			$variationFieldName = 'variation_' . $fieldName;
+			if (isset($build[$variationFieldName])) {
+				if (isset($build['injected_variation_fields'])) {
+					$build['injected_variation_fields'][$variationFieldName] = $build[$variationFieldName];
+				}
+				unset($build[$variationFieldName]);
 			}
-			unset($build[$variationFieldName]);
 		}
-	}
 
-	// Remove injected product variation attributes.
-	if (isset($build['variation_attributes'])) {
-		if (isset($build['injected_variation_fields'])) {
-			$build['injected_variation_fields']['variation_attributes'] = $build['variation_attributes'];
+		// Remove injected product variation attributes.
+		if (isset($build['variation_attributes'])) {
+			if (isset($build['injected_variation_fields'])) {
+				$build['injected_variation_fields']['variation_attributes'] = $build['variation_attributes'];
+			}
+			unset($build['variation_attributes']);
 		}
-		unset($build['variation_attributes']);
-	}
 
+	}
 }


### PR DESCRIPTION
When a product has no variations we are currently getting WSOD cause we pass NULL to renderFields function.

This PR adds validation before calling this function to prevent such error.